### PR TITLE
The device_suffix in a test_name is "privateuse1" sometimes.

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -506,7 +506,8 @@ class DeviceTypeTestBase(TestCase):
             decorator_fn,
         ) in parametrize_fn(test, generic_cls, cls):
             test_suffix = "" if test_suffix == "" else "_" + test_suffix
-            device_suffix = "_" + cls.device_type
+            cls_device_type = cls.device_type if cls.device_type != "privateuse1" else torch._C._get_privateuse1_backend_name()
+            device_suffix = "_" + cls_device_type
 
             # Note: device and dtype suffix placement
             # Special handling here to place dtype(s) after device according to test name convention.


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
When run some test cases on the privateuse1 device, the device_suffix in a test_name is 'privateuse1' sometimes.
For examples, a test_name is 'test_Dropout1d_npu', while it would be 'test_Dropout1d_privateuse1' sometimes. 
When setUpClass() didn't set it, the device_suffix woulde be "privateuse1".